### PR TITLE
Finalized the `createChannel` API

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -2,36 +2,9 @@
 
 import { onmessage } from './utils.js';
 
-class ChannelEvent extends Event {
-  #port;
-  #channel;
-
-  get port() { return this.#port }
-  get channel() { return this.#channel }
-
-  /**
-   * @param {string} type
-   * @param {MessagePort} port
-   * @param {Promise<Readonly<import("./utils.js").Channel>>} channel
-   */
-  constructor(type, port, channel) {
-    super(type);
-    this.#port = port;
-    this.#channel = channel;
+addEventListener('connect', event => {
+  for (const port of /** @type {MessageEvent<any>} */(event).ports) {
+    port.start();
+    onmessage(port);
   }
-}
-
-const ports = new EventTarget;
-export default ports;
-
-addEventListener(
-  'connect',
-  event => {
-    for (const port of /** @type {MessageEvent<any>} */(event).ports) {
-      port.start();
-      ports.dispatchEvent(
-        new ChannelEvent(event.type, port, onmessage(port))
-      );
-    }
-  }
-);
+});

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,4 +1,4 @@
 //@ts-check
 
 import { onmessage } from './utils.js';
-export default onmessage(self);
+onmessage(self);

--- a/test/index.html
+++ b/test/index.html
@@ -5,4 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="module" src="index.js"></script>
 </head>
+<body><pre>shared-back
+shared-channel-back
+worker-back
+worker-channel-back</pre>⏰</body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,28 @@
-import { SharedWorker, Worker, channel } from '../src/main.js';
+import { SharedWorker, Worker } from '../src/main.js';
+
+const results = [];
+const logData = name => ({ data }) => {
+  console.log(`${name}-back`, { data });
+  if (results.push(`${name}-back`) === 4) {
+    results.sort();
+    document.body.innerHTML = `<pre>${results.join('\n')}</pre>✅`;
+    sw.port.close();
+    wc.terminate();
+  }
+};
 
 const sw = new SharedWorker('./shared.js');
+sw.port.addEventListener('message', logData('shared'));
 sw.port.postMessage('default');
-channel.get(sw).postMessage('channel');
+
+const swc = sw.port.createChannel();
+swc.addEventListener('message', logData('shared-channel'));
+swc.postMessage('channel');
 
 const wc = new Worker('./worker.js');
+wc.addEventListener('message', logData('worker'));
 wc.postMessage('default');
-channel.get(wc).postMessage('channel');
+
+const wcc = wc.createChannel();
+wcc.addEventListener('message', logData('worker-channel'));
+wcc.postMessage('channel');

--- a/test/shared.js
+++ b/test/shared.js
@@ -1,13 +1,7 @@
-import ports from '../src/shared.js';
+import '../src/shared.js';
+import logger from './utils.js';
 
-ports.addEventListener(
-  'connect',
-  async event => {
-    const logData = ({ data }) => console.log({ data });
-    event.port.addEventListener('message', logData);
-
-    const { id, port } = await event.channel;
-    console.log('shared', event.port, { id, port });
-    port.addEventListener('message', logData);
-  }
-);
+addEventListener('connect', ({ ports }) => {
+  for (const port of ports)
+    logger(port, 'shared');
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,15 @@
+
+const logData = name => ({ data, target }) => {
+  console.log(name, { data });
+  target.postMessage(data);
+};
+
+export default (self, prefix) => {
+  self.addEventListener('message', logData(prefix));
+
+  self.addEventListener('channel', event => {
+    const { ports: [port], target } = event;
+    console.assert(port === target, 'port and target are the same');
+    port.addEventListener('message', logData(`${prefix}-channel`));
+  });
+};

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,8 +1,5 @@
-import channel from '../src/worker.js';
+import '../src/worker.js';
+import logger from './utils.js';
 
-const logData = ({ data }) => console.log({ data });
-addEventListener('message', logData);
+logger(self, 'worker');
 
-const { id, port } = await channel;
-console.log('worker', { id, port });
-port.addEventListener('message', logData);


### PR DESCRIPTION
This MR uses a different approach:

  * it never attaches a *channel* by default ... **but** ...
  * it allows anyone with access to the *Worker* or *SharedWorker.port* to `createChannel()` whenever is needed/convenient
  * it closes all channels created on `worker.terminate()` or `sharedWorker.port.close()`